### PR TITLE
Fall back to the control plane on a stale session JWT

### DIFF
--- a/src/lib/browser-routing.ts
+++ b/src/lib/browser-routing.ts
@@ -23,6 +23,15 @@ export class BrowserRouteCache {
     this.entries.delete(sessionId);
   }
 
+  deleteIfJwt(sessionId: string, jwt: string): boolean {
+    const route = this.entries.get(sessionId);
+    if (!route || route.jwt !== jwt) {
+      return false;
+    }
+    this.entries.delete(sessionId);
+    return true;
+  }
+
   clear(): void {
     this.entries.clear();
   }
@@ -265,7 +274,7 @@ async function routeRequest(
   headers.delete('authorization');
   const routed = await innerFetch(target.toString(), buildRoutedInit(input, request, init, headers));
   if ((routed.status === 401 || routed.status === 403) && target.searchParams.get('jwt')) {
-    cache.delete(sessionId);
+    cache.deleteIfJwt(sessionId, target.searchParams.get('jwt') ?? '');
     await CancelReadableStream(routed.body);
     return innerFetch(input, init);
   }

--- a/src/lib/browser-routing.ts
+++ b/src/lib/browser-routing.ts
@@ -1,4 +1,5 @@
 import type { Fetch, RequestInfo, RequestInit } from '../internal/builtin-types';
+import { CancelReadableStream } from '../internal/shims';
 import { joinURL } from './join-url';
 
 export type BrowserRoute = {
@@ -265,6 +266,7 @@ async function routeRequest(
   const routed = await innerFetch(target.toString(), buildRoutedInit(input, request, init, headers));
   if ((routed.status === 401 || routed.status === 403) && target.searchParams.get('jwt')) {
     cache.delete(sessionId);
+    await CancelReadableStream(routed.body);
     return innerFetch(input, init);
   }
   return routed;

--- a/src/lib/browser-routing.ts
+++ b/src/lib/browser-routing.ts
@@ -262,7 +262,12 @@ async function routeRequest(
 
   const headers = new Headers(request.headers);
   headers.delete('authorization');
-  return innerFetch(target.toString(), buildRoutedInit(input, request, init, headers));
+  const routed = await innerFetch(target.toString(), buildRoutedInit(input, request, init, headers));
+  if ((routed.status === 401 || routed.status === 403) && target.searchParams.get('jwt')) {
+    cache.delete(sessionId);
+    return innerFetch(input, init);
+  }
+  return routed;
 }
 
 function buildRoutedInit(

--- a/tests/lib/browser-routing.test.ts
+++ b/tests/lib/browser-routing.test.ts
@@ -590,4 +590,43 @@ describe('browser routing', () => {
       ]);
     });
   });
+
+  test('falls back to the control plane on a stale direct-VM JWT', async () => {
+    await withBrowserRoutingEnv(undefined, async () => {
+      const calls: Array<{ url: string; headers: Headers }> = [];
+      const kernel = new Kernel({
+        apiKey: 'k',
+        baseURL: 'https://api.example/',
+        fetch: async (input, init?: RequestInit) => {
+          const url = normalizeURL(input);
+          const headers = input instanceof Request ? new Headers(input.headers) : new Headers(init?.headers);
+          calls.push({ url, headers });
+          if (url === 'https://api.example/browsers') {
+            return Response.json({
+              session_id: 'sess-1',
+              base_url: 'http://browser-session.test/browser/kernel',
+              cdp_ws_url: 'wss://browser-session.test/browser/cdp?jwt=token-abc',
+            });
+          }
+          if (url.includes('browser-session.test')) {
+            return new Response('Invalid JWT', { status: 401, headers: { 'content-type': 'text/plain' } });
+          }
+          return new Response(new Uint8Array([1, 2, 3]), {
+            status: 200,
+            headers: { 'content-type': 'image/png' },
+          });
+        },
+      });
+
+      await kernel.browsers.create();
+      await kernel.browsers.computer.captureScreenshot('sess-1');
+
+      expect(calls[1]?.url).toBe(
+        'http://browser-session.test/browser/kernel/computer/screenshot?jwt=token-abc',
+      );
+      expect(calls[2]?.url).toBe('https://api.example/browsers/sess-1/computer/screenshot');
+      expect(calls[2]?.headers.get('authorization')).toBe('Bearer k');
+      expect(kernel.browserRouteCache.get('sess-1')).toBeUndefined();
+    });
+  });
 });

--- a/tests/lib/browser-routing.test.ts
+++ b/tests/lib/browser-routing.test.ts
@@ -629,4 +629,39 @@ describe('browser routing', () => {
       expect(kernel.browserRouteCache.get('sess-1')).toBeUndefined();
     });
   });
+
+  test('does not evict a refreshed route after a stale JWT 401', async () => {
+    await withBrowserRoutingEnv(undefined, async () => {
+      const kernel = new Kernel({
+        apiKey: 'k',
+        baseURL: 'https://api.example/',
+        fetch: async (input) => {
+          const url = normalizeURL(input);
+          if (url === 'https://api.example/browsers') {
+            return Response.json({
+              session_id: 'sess-1',
+              base_url: 'http://browser-session.test/browser/kernel',
+              cdp_ws_url: 'wss://browser-session.test/browser/cdp?jwt=token-abc',
+            });
+          }
+          if (url.includes('browser-session.test')) {
+            kernel.browserRouteCache.set({
+              sessionId: 'sess-1',
+              baseURL: 'http://browser-session.test/browser/kernel',
+              jwt: 'jwt-FRESH',
+            });
+            return new Response('Invalid JWT', { status: 401, headers: { 'content-type': 'text/plain' } });
+          }
+          return new Response(new Uint8Array([1, 2, 3]), {
+            status: 200,
+            headers: { 'content-type': 'image/png' },
+          });
+        },
+      });
+
+      await kernel.browsers.create();
+      await kernel.browsers.computer.captureScreenshot('sess-1');
+      expect(kernel.browserRouteCache.get('sess-1')).toMatchObject({ jwt: 'jwt-FRESH' });
+    });
+  });
 });


### PR DESCRIPTION
## Summary

A direct-to-VM `401`/`403` with a session `jwt` query param now evicts the cached route and retries the original request against the API.

This is the same fallback as kernel-python-sdk#157. It did not land in #170 because that PR merged before this commit.

Retry keys off the request JWT, not a still-present cache entry, so concurrent 401s still fall back after the first eviction.

## Test plan

- [x] `jest tests/lib/browser-routing.test.ts`
- [x] screenshot 401 on metro retries on the API origin with Authorization
- [x] cached route is evicted after the stale JWT

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches request routing and JWT cache eviction for browser sessions. Incorrect eviction or retry could drop a valid route or loop auth failures, but the change is small and JWT-keyed.
> 
> **Overview**
> Direct-to-VM browser requests that return **401/403** with a session `jwt` now drop that cached route and retry the original call on the control plane (with `Authorization`).
> 
> Eviction uses `deleteIfJwt` so only the JWT that failed is removed. A route that was refreshed concurrently is left in place. The failed VM response body is cancelled before the retry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31517bb54106be666c81812564d2e7e0a7f1e17c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->