### PR TITLE
feat: route process calls directly to browser VMs

### DIFF
--- a/src/lib/browser-routing.ts
+++ b/src/lib/browser-routing.ts
@@ -41,7 +41,13 @@ const BROWSER_ROUTING_SUBRESOURCES_ENV = 'KERNEL_BROWSER_ROUTING_SUBRESOURCES';
 // Path prefixes eligible for direct-to-VM routing. "telemetry/stream" is the live
 // SSE endpoint (served by the VM); "telemetry/events" is a historical read served
 // by the control plane (S2) and must NOT be here.
-const DEFAULT_BROWSER_ROUTING_SUBRESOURCES = ['curl', 'telemetry/stream', 'computer', 'playwright'];
+const DEFAULT_BROWSER_ROUTING_SUBRESOURCES = [
+  'curl',
+  'telemetry/stream',
+  'computer',
+  'playwright',
+  'process',
+];
 const BROWSER_ROUTE_CACHEABLE_PATH = /^\/(?:v\d+\/)?browsers(?:\/[^/]+)?\/?$/;
 const BROWSER_POOL_ACQUIRE_PATH = /^\/(?:v\d+\/)?browser_pools\/[^/]+\/acquire\/?$/;
 const BROWSER_DELETE_BY_ID_PATH = /^\/(?:v\d+\/)?browsers\/([^/]+)\/?$/;

--- a/tests/lib/browser-routing.test.ts
+++ b/tests/lib/browser-routing.test.ts
@@ -451,12 +451,13 @@ describe('browser routing', () => {
         'telemetry/stream',
         'computer',
         'playwright',
+        'process',
       ]);
     });
   });
 
   test('allowlist matching is segment-boundary aware (telemetry/events stays on the control plane)', () => {
-    const prefixes = ['curl', 'telemetry/stream', 'computer', 'playwright'];
+    const prefixes = ['curl', 'telemetry/stream', 'computer', 'playwright', 'process'];
     expect(matchesDirectVMPrefix('telemetry/stream', prefixes)).toBe(true);
     expect(matchesDirectVMPrefix('telemetry/stream/x', prefixes)).toBe(true);
     expect(matchesDirectVMPrefix('telemetry/events', prefixes)).toBe(false);
@@ -465,7 +466,8 @@ describe('browser routing', () => {
     expect(matchesDirectVMPrefix('curl/raw', prefixes)).toBe(true);
     expect(matchesDirectVMPrefix('computer/screenshot', prefixes)).toBe(true);
     expect(matchesDirectVMPrefix('playwright/execute', prefixes)).toBe(true);
-    expect(matchesDirectVMPrefix('process/exec', prefixes)).toBe(false);
+    expect(matchesDirectVMPrefix('process/exec', prefixes)).toBe(true);
+    expect(matchesDirectVMPrefix('process/proc-1/stdout/stream', prefixes)).toBe(true);
     expect(matchesDirectVMPrefix('fs/read', prefixes)).toBe(false);
   });
 
@@ -507,7 +509,7 @@ describe('browser routing', () => {
     });
   });
 
-  test('routes computer screenshot and playwright execute to the VM by default', async () => {
+  test('routes default browser subresources to the VM', async () => {
     await withBrowserRoutingEnv(undefined, async () => {
       const calls: Array<{ url: string; headers: Headers }> = [];
       const kernel = new Kernel({
@@ -530,6 +532,9 @@ describe('browser routing', () => {
               headers: { 'content-type': 'image/png' },
             });
           }
+          if (url.includes('/process/exec')) {
+            return Response.json({ exit_code: 0, stdout_b64: '', stderr_b64: '' });
+          }
           return Response.json({ success: true });
         },
       });
@@ -537,6 +542,7 @@ describe('browser routing', () => {
       await kernel.browsers.create();
       await kernel.browsers.computer.captureScreenshot('sess-1');
       await kernel.browsers.playwright.execute('sess-1', { code: 'return 1' });
+      await kernel.browsers.process.exec('sess-1', { command: 'echo' });
 
       expect(calls[1]?.url).toBe(
         'http://browser-session.test/browser/kernel/computer/screenshot?jwt=token-abc',
@@ -546,10 +552,12 @@ describe('browser routing', () => {
         'http://browser-session.test/browser/kernel/playwright/execute?jwt=token-abc',
       );
       expect(calls[2]?.headers.get('authorization')).toBeNull();
+      expect(calls[3]?.url).toBe('http://browser-session.test/browser/kernel/process/exec?jwt=token-abc');
+      expect(calls[3]?.headers.get('authorization')).toBeNull();
     });
   });
 
-  test('keeps process, fs, and telemetry/events on the API origin by default', async () => {
+  test('keeps fs and telemetry/events on the API origin by default', async () => {
     await withBrowserRoutingEnv(undefined, async () => {
       const calls: string[] = [];
       const kernel = new Kernel({
@@ -579,12 +587,10 @@ describe('browser routing', () => {
       });
 
       await kernel.browsers.create();
-      await kernel.browsers.process.exec('sess-1', { command: 'echo' });
       await kernel.browsers.fs.readFile('sess-1', { path: '/tmp/x' });
       await kernel.browsers.telemetry.events('sess-1');
 
       expect(calls.slice(1)).toEqual([
-        'https://api.example/browsers/sess-1/process/exec',
         'https://api.example/browsers/sess-1/fs/read_file?path=%2Ftmp%2Fx',
         'https://api.example/browsers/sess-1/telemetry/events',
       ]);


### PR DESCRIPTION
## summary

- add `process` to the default direct-to-VM browser routing allowlist
- cover process exec, spawn, kill, resize, status, stdin, and stdout streaming through the existing prefix matcher
- keep `fs/*` and `telemetry/events` on the control plane and preserve the environment override/kill switch

## testing

- `yarn test` (410 passed, 227 skipped)
- `yarn lint`
- live browser validation: exec, spawn, and stdout streaming routed through `/browser/kernel/process/...` and returned the expected output

## release

This PR targets `next`. After merge, release-please opens or updates the versioned `next → main` release PR. Merging that release PR publishes the npm package.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Default routing for all `process/*` browser calls changes from control plane to VM, which affects latency, failure modes, and auth for existing SDK users unless they override env; scope is limited to browser subresource routing with existing JWT fallback behavior.
> 
> **Overview**
> Adds **`process`** to the default direct-to-VM browser routing allowlist in `browser-routing.ts`, so paths like `process/exec` and `process/.../stdout/stream` match the existing prefix rules and are sent to the session VM (JWT on the VM URL, API `authorization` stripped) instead of the control plane API origin.
> 
> **`fs/*`** and **`telemetry/events`** remain on the API by default; **`KERNEL_BROWSER_ROUTING_SUBRESOURCES`** still overrides or disables routing when set.
> 
> Tests now expect `process` in the default list, assert prefix matching for process paths, include `process.exec` in the default VM routing integration test, and drop process from the “stays on API origin” case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e1a0535a4dde5ff635a7a6fc1f57c8119d410ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->